### PR TITLE
Added dependencies to ensure post class at the end

### DIFF
--- a/sat6-iptables/manifests/init.pp
+++ b/sat6-iptables/manifests/init.pp
@@ -61,15 +61,21 @@ class iptables (
       before  => Class['iptables::post'],
     }
 
-    # Load pre/post rules
-    class { ['iptables::pre', 'iptables::post']: }
+    # Load pre rules
+    class { 'iptables::pre': }
 
     # Load all required roles
-    class { $role: }
+    class { $role: 
+      before => Class['iptables::post']
+    }
+
+    # Load post rules
+    class { 'iptables::post': }
   }
 
   # Ensure service status
   class { 'firewall':
-    ensure => $enabled? { true => running, default => stopped },
+    ensure  => $enabled? { true => running, default => stopped },
+    require => Class['iptables::post']
   }
 }


### PR DESCRIPTION
I have added flow control to ensure the post rules are added at the end of the execution. Otherwise, if the default value for policy is reject, it can stop the execution breaking connection.